### PR TITLE
Comment Append Bugfix

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -532,20 +532,22 @@ function s:AppendCommentToLine()
     let lenRight = strlen(right)
 
     let isLineEmpty = strlen(getline(".")) == 0
-    let insOrApp = (isLineEmpty==1 ? 'i' : 'A')
+    let insOrApp = (isLineEmpty==1 ? 'i' : 'A ')
 
     "stick the delimiters down at the end of the line. We have to format the
     "comment with spaces as appropriate
-    execute ":normal! " . insOrApp . (isLineEmpty ? '' : ' ') . left . " " . right 
+    execute ":normal! " . insOrApp . left . " " . right 
 
     " if there is a right delimiter then we gotta move the cursor left
     " by the len of the right delimiter so we insert between the delimiters
     if lenRight > 0
-        let leftMoveAmount = lenRight
+        let leftMoveAmount = lenRight - 1
         execute ":normal! " . leftMoveAmount . "h"
+        startinsert
+    else
+      "Keep the cursor to the right of the appended whitespace.
+      startinsert!
     endif
-    startinsert
-    call cursor(0, col('.')+1)
 endfunction
 
 " Function: s:CommentBlock(top, bottom, lSide, rSide, forceNested ) {{{2

--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -536,7 +536,7 @@ function s:AppendCommentToLine()
 
     "stick the delimiters down at the end of the line. We have to format the
     "comment with spaces as appropriate
-    execute ":normal! " . insOrApp . (isLineEmpty ? '' : ' ') . left . right . " "
+    execute ":normal! " . insOrApp . (isLineEmpty ? '' : ' ') . left . " " . right 
 
     " if there is a right delimiter then we gotta move the cursor left
     " by the len of the right delimiter so we insert between the delimiters
@@ -545,6 +545,7 @@ function s:AppendCommentToLine()
         execute ":normal! " . leftMoveAmount . "h"
     endif
     startinsert
+    call cursor(0, col('.')+1)
 endfunction
 
 " Function: s:CommentBlock(top, bottom, lSide, rSide, forceNested ) {{{2


### PR DESCRIPTION
When appending a comment, a space is appended to the end of the line, rather than between the left and right delimiters. This patch moves the whitespace to the correct location, then positions the cursor accordingly.