### PR TITLE
Updated the asymptote (.asy) comments to include multiline delimiters

### DIFF
--- a/plugin/NERD_commenter.vim
+++ b/plugin/NERD_commenter.vim
@@ -86,7 +86,7 @@ let s:delimiterMap = {
     \ 'asp': { 'leftAlt': '%*','rightAlt': '*%', 'left': '%' },
     \ 'aspvbs': { 'left': '''', 'leftAlt': '<!--', 'rightAlt': '-->' },
     \ 'asterisk': { 'left': ';' },
-    \ 'asy': { 'left': '//' },
+    \ 'asy': { 'left': '//', 'leftAlt': '/*', 'rightAlt': '*/' },
     \ 'atlas': { 'left': 'C', 'right': '$' },
     \ 'autohotkey': { 'left': ';' },
     \ 'autoit': { 'left': ';' },


### PR DESCRIPTION
Asymptote supports the C-style /* ... */ comments. They are added in this patch.